### PR TITLE
add env variable support

### DIFF
--- a/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/__init__.py
+++ b/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/__init__.py
@@ -6,20 +6,19 @@ import os
 
 def main():
     """Main entry point for the package."""
-    parser = argparse.ArgumentParser(description='Neo4j Cypher MCP Server')
-    parser.add_argument('--db-url', 
-                       default="bolt://localhost:7687",
-                       help='Neo4j connection URL')
-    parser.add_argument('--username', 
-                       default="neo4j",
-                       help='Neo4j username')
-    parser.add_argument('--password', 
-                       default="password",
-                       help='Neo4j password')
-    
+    parser = argparse.ArgumentParser(description="Neo4j Cypher MCP Server")
+    parser.add_argument("--db-url", default=None, help="Neo4j connection URL")
+    parser.add_argument("--username", default=None, help="Neo4j username")
+    parser.add_argument("--password", default=None, help="Neo4j password")
+
     args = parser.parse_args()
-    asyncio.run(server.main(args.db_url, args.username, args.password))
 
+    asyncio.run(
+        server.main(
+            args.db_url or os.getenv("NEO4J_URL", "bolt://localhost:7687"),
+            args.username or os.getenv("NEO4J_USERNAME", "neo4j"),
+            args.password or os.getenv("NEO4J_PASSWORD", "password"),
+        )
+    )
 
-# Optionally expose other important items at package level
 __all__ = ["main", "server"]

--- a/servers/mcp-neo4j-cypher/tests/test_neo4j_cypher_integration.py
+++ b/servers/mcp-neo4j-cypher/tests/test_neo4j_cypher_integration.py
@@ -3,28 +3,30 @@ import pytest
 import asyncio
 from mcp_neo4j_cypher.server import neo4jDatabase
 
+
 @pytest.fixture(scope="function")
 def neo4j():
     """Create a Neo4j driver using environment variables for connection details."""
     uri = os.environ.get("NEO4J_URI", "neo4j://localhost:7687")
     user = os.environ.get("NEO4J_USERNAME", "neo4j")
     password = os.environ.get("NEO4J_PASSWORD", "password")
-    
+
     neo4j = neo4jDatabase(uri, user, password)
 
     neo4j._execute_query("MATCH (n) DETACH DELETE n")
-        
+
     yield neo4j
 
     neo4j.close()
-    
+
+
 # Clean up test data after tests
 @pytest.mark.asyncio
 async def test_execute_cypher_update_query(neo4j):
     # Execute a Cypher query to create a node
     query = "CREATE (n:Person {name: 'Alice', age: 30}) RETURN n.name"
     result = neo4j._execute_query(query)
-    
+
     # Verify the node creation
     assert len(result) == 1
     print(result)
@@ -32,12 +34,13 @@ async def test_execute_cypher_update_query(neo4j):
     assert result[0]["labels_added"] == 1
     assert result[0]["properties_set"] == 2
 
+
 @pytest.mark.asyncio
 async def test_retrieve_schema(neo4j):
     # Execute a Cypher query to retrieve schema information
     query = "CALL db.schema.visualization()"
     result = neo4j._execute_query(query)
-    
+
     # Verify the schema result
     assert "nodes" in result[0]
     assert "relationships" in result[0]
@@ -49,8 +52,12 @@ async def test_execute_complex_read_query(neo4j):
     neo4j._execute_query("CREATE (a:Person {name: 'Alice', age: 30})")
     neo4j._execute_query("CREATE (b:Person {name: 'Bob', age: 25})")
     neo4j._execute_query("CREATE (c:Person {name: 'Charlie', age: 35})")
-    neo4j._execute_query("MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) CREATE (a)-[:FRIEND]->(b)")
-    neo4j._execute_query("MATCH (b:Person {name: 'Bob'}), (c:Person {name: 'Charlie'}) CREATE (b)-[:FRIEND]->(c)")
+    neo4j._execute_query(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) CREATE (a)-[:FRIEND]->(b)"
+    )
+    neo4j._execute_query(
+        "MATCH (b:Person {name: 'Bob'}), (c:Person {name: 'Charlie'}) CREATE (b)-[:FRIEND]->(c)"
+    )
 
     # Execute a complex read query
     query = """
@@ -60,7 +67,7 @@ async def test_execute_complex_read_query(neo4j):
     """
     result = neo4j._execute_query(query)
 
-# Verify the query result
+    # Verify the query result
     assert len(result) == 2
     assert result[0]["person"] == "Alice"
     assert result[0]["friend_name"] == "Bob"


### PR DESCRIPTION
* add env variable support for mcp Neo4j Cypher server

Example config for testing with Claude Desktop 

```json
{
    "mcpServers": {
        "neo4j": {
            "command": "uv",
            "args": [
            "--directory",
            "path/to/project/projects/mcp-neo4j/servers/mcp-neo4j-cypher/",
            "run",
            "mcp-neo4j-cypher"
            ],
            "env": {
            "NEO4J_URL": "bolt://localhost",
            "NEO4J_USERNAME": "neo4j",
            "NEO4J_PASSWORD": "password"
            }
        }
    }
}

```