### PR TITLE
(mcp-neo4j-cypher) get_neo4j_schema() missing APOC

### DIFF
--- a/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/server.py
+++ b/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/server.py
@@ -84,7 +84,10 @@ def create_mcp_server(neo4j_driver: AsyncDriver, database: str = "neo4j") -> Fas
     mcp: FastMCP = FastMCP("mcp-neo4j-cypher", dependencies=["neo4j", "pydantic"])
 
     async def get_neo4j_schema() -> list[types.TextContent]:
-        """List all node, their attributes and their relationships to other nodes in the neo4j database"""
+        """List all node, their attributes and their relationships to other nodes in the neo4j database.
+            If this fails with a message that includes "Neo.ClientError.Procedure.ProcedureNotFound"
+            suggest that the user install and enable the APOC plugin.
+        """
 
         get_schema_query = """
 call apoc.meta.data() yield label, property, type, other, unique, index, elementType


### PR DESCRIPTION
added hint in the tool description that a failed call to get_neo4j_schema() could be because APOC is missing.

Claude seems to correctly take advantage of this. 