### PR TITLE
fix: correct typos in servers/mcp-neo4j-cypher/README.md

### DIFF
--- a/servers/mcp-neo4j-cypher/README.md
+++ b/servers/mcp-neo4j-cypher/README.md
@@ -230,7 +230,7 @@ docker run --rm -p 8000:8000 \
   -e NEO4J_MCP_SERVER_HOST="0.0.0.0" \
   -e NEO4J_MCP_SERVER_PORT="8000" \
   -e NEO4J_MCP_SERVER_PATH="/api/mcp/" \
-  mcp/neo4j-cypher:latest
+  mcp-neo4j-cypher:latest
 ```
 
 ### 🔧 Environment Variables


### PR DESCRIPTION
# Description

Fixed the Docker image name in the README.md file, changing it from
`mcp/neo4j-cypher:latest` to `mcp-neo4j-cypher:latest.`

# Why?

This change allows us to use the Docker image we previously built locally, instead of relying on the Docker Hub version, which is not synchronized with the GitHub repository and can cause errors