### PR TITLE
Docs: Update mcp-neo4j-cypher command argument flags

### DIFF
--- a/servers/mcp-neo4j-cypher/README.md
+++ b/servers/mcp-neo4j-cypher/README.md
@@ -105,7 +105,7 @@ For custom HTTP configurations beyond the defaults:
 
 ```bash
 # Custom HTTP configuration
-mcp-neo4j-cypher --transport http --host 0.0.0.0 --port 8080 --path /api/mcp/
+mcp-neo4j-cypher --transport http --server-host 0.0.0.0 --server-port 8080 --server-path /api/mcp/
 
 # Or using environment variables
 export NEO4J_TRANSPORT=http


### PR DESCRIPTION
Use `--server-xxx` for http server config flags
<img width="568" height="223" alt="neo4j-mcp" src="https://github.com/user-attachments/assets/a451326d-cb75-47bf-9550-4e098b25b5cb" />
