### PR TITLE
Update http examples to not bind to all interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ To run a server in HTTP mode, use the `--transport http` flag:
 mcp-neo4j-cypher --transport http
 
 # Custom HTTP configuration
-mcp-neo4j-cypher --transport http --host 0.0.0.0 --port 8080 --path /api/mcp/
+mcp-neo4j-cypher --transport http --host 127.0.0.1 --port 8080 --path /api/mcp/
 ```
 
 Environment variables are also supported:
 
 ```bash
 export NEO4J_TRANSPORT=http
-export NEO4J_MCP_SERVER_HOST=0.0.0.0
+export NEO4J_MCP_SERVER_HOST=127.0.0.1
 export NEO4J_MCP_SERVER_PORT=8080
 export NEO4J_MCP_SERVER_PATH=/api/mcp/
 mcp-neo4j-cypher

--- a/servers/mcp-neo4j-cloud-aura-api/README.md
+++ b/servers/mcp-neo4j-cloud-aura-api/README.md
@@ -173,14 +173,14 @@ The server supports HTTP transport for web-based deployments and microservices:
 mcp-neo4j-aura-manager --transport http
 
 # Custom HTTP configuration
-mcp-neo4j-aura-manager --transport http --host 0.0.0.0 --port 8080 --path /api/mcp/
+mcp-neo4j-aura-manager --transport http --host 127.0.0.1 --port 8080 --path /api/mcp/
 ```
 
 Environment variables for HTTP configuration:
 
 ```bash
 export NEO4J_TRANSPORT=http
-export NEO4J_MCP_SERVER_HOST=0.0.0.0
+export NEO4J_MCP_SERVER_HOST=127.0.0.1
 export NEO4J_MCP_SERVER_PORT=8080
 export NEO4J_MCP_SERVER_PATH=/api/mcp/
 mcp-neo4j-aura-manager

--- a/servers/mcp-neo4j-cypher/README.md
+++ b/servers/mcp-neo4j-cypher/README.md
@@ -105,11 +105,11 @@ For custom HTTP configurations beyond the defaults:
 
 ```bash
 # Custom HTTP configuration
-mcp-neo4j-cypher --transport http --server-host 0.0.0.0 --server-port 8080 --server-path /api/mcp/
+mcp-neo4j-cypher --transport http --server-host 127.0.0.1 --server-port 8080 --server-path /api/mcp/
 
 # Or using environment variables
 export NEO4J_TRANSPORT=http
-export NEO4J_MCP_SERVER_HOST=0.0.0.0
+export NEO4J_MCP_SERVER_HOST=127.0.0.1
 export NEO4J_MCP_SERVER_PORT=8080
 export NEO4J_MCP_SERVER_PATH=/api/mcp/
 mcp-neo4j-cypher
@@ -174,7 +174,7 @@ Syntax with `--db-url`, `--username`, `--password` and other command line argume
       "--transport",
       "sse",
       "--server-host",
-      "0.0.0.0",
+      "127.0.0.1",
       "--server-port",
       "8000"
       "--server-path",

--- a/servers/mcp-neo4j-data-modeling/README.md
+++ b/servers/mcp-neo4j-data-modeling/README.md
@@ -178,14 +178,14 @@ The server supports HTTP transport for web-based deployments and microservices:
 mcp-neo4j-data-modeling --transport http
 
 # Custom HTTP configuration
-mcp-neo4j-data-modeling --transport http --host 0.0.0.0 --port 8080 --path /api/mcp/
+mcp-neo4j-data-modeling --transport http --host 127.0.0.1 --port 8080 --path /api/mcp/
 ```
 
 Environment variables for HTTP configuration:
 
 ```bash
 export MCP_TRANSPORT=http
-export NEO4J_MCP_SERVER_HOST=0.0.0.0
+export NEO4J_MCP_SERVER_HOST=127.0.0.1
 export NEO4J_MCP_SERVER_PORT=8080
 export NEO4J_MCP_SERVER_PATH=/api/mcp/
 mcp-neo4j-data-modeling

--- a/servers/mcp-neo4j-memory/README.md
+++ b/servers/mcp-neo4j-memory/README.md
@@ -156,14 +156,14 @@ The server supports HTTP transport for web-based deployments and microservices:
 mcp-neo4j-memory --transport http
 
 # Custom HTTP configuration
-mcp-neo4j-memory --transport http --host 0.0.0.0 --port 8080 --path /api/mcp/
+mcp-neo4j-memory --transport http --host 127.0.0.1 --port 8080 --path /api/mcp/
 ```
 
 Environment variables for HTTP configuration:
 
 ```bash
 export NEO4J_TRANSPORT=http
-export NEO4J_MCP_SERVER_HOST=0.0.0.0
+export NEO4J_MCP_SERVER_HOST=127.0.0.1
 export NEO4J_MCP_SERVER_PORT=8080
 export NEO4J_MCP_SERVER_PATH=/api/mcp/
 mcp-neo4j-memory


### PR DESCRIPTION
This doesn't touch any of the docker examples as this comment suggests it might break things: https://github.com/neo4j-contrib/mcp-neo4j/blob/a6f12581bcf0f20dbbfe6968e9ad8e8514e7ba08/servers/mcp-neo4j-cypher/docker-compose.yml#L24