### PR TITLE
cypher - add warnings and info for server config, update changelog

### DIFF
--- a/servers/mcp-neo4j-cypher/CHANGELOG.md
+++ b/servers/mcp-neo4j-cypher/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Update Neo4j Driver syntax to use `driver.execute_query(...)`. This cleans the driver code.
 
 ### Added
+* Add clear warnings for config declaration via cli and env variables
 
 ## v0.3.0
 

--- a/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/__init__.py
+++ b/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/__init__.py
@@ -3,6 +3,7 @@ import asyncio
 import os
 
 from . import server
+from .utils import process_config
 
 
 def main():
@@ -19,19 +20,8 @@ def main():
     parser.add_argument("--server-port", default=None, help="Server port")
 
     args = parser.parse_args()
-    asyncio.run(
-        server.main(
-            args.db_url or os.getenv("NEO4J_URL") or os.getenv("NEO4J_URI", "bolt://localhost:7687"),
-            args.username or os.getenv("NEO4J_USERNAME", "neo4j"),
-            args.password or os.getenv("NEO4J_PASSWORD", "password"),
-            args.database or os.getenv("NEO4J_DATABASE", "neo4j"),
-            args.transport or os.getenv("NEO4J_TRANSPORT", "stdio"),
-            args.namespace or os.getenv("NEO4J_NAMESPACE", ""),
-            args.server_host or os.getenv("NEO4J_MCP_SERVER_HOST", "127.0.0.1"),
-            args.server_port or int(os.getenv("NEO4J_MCP_SERVER_PORT", "8000")),
-            args.server_path or os.getenv("NEO4J_MCP_SERVER_PATH", "/mcp/"),
-        )
-    )
+    config = process_config(args)   
+    asyncio.run(server.main(**config))
 
 
 __all__ = ["main", "server"]

--- a/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/utils.py
+++ b/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/utils.py
@@ -1,0 +1,142 @@
+import argparse
+import os
+import logging
+from typing import Union
+
+logger = logging.getLogger("mcp_neo4j_cypher")
+logger.setLevel(logging.INFO)
+
+def process_config(args: argparse.Namespace) -> dict[str, Union[str, int, None]]:
+    """
+    Process the command line arguments and environment variables to create a config dictionary. 
+    This may then be used as input to the main server function.
+    If any value is not provided, then a warning is logged and a default value is used, if appropriate.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        The command line arguments.
+
+    Returns
+    -------
+    config : dict[str, str]
+        The configuration dictionary.
+    """
+
+    config = dict()
+
+    # parse uri
+    if args.db_url is not None:
+        config["db_url"] = args.db_url
+    else:
+        if os.getenv("NEO4J_URL") is not None:
+            config["db_url"] = os.getenv("NEO4J_URL")
+        else:
+            if os.getenv("NEO4J_URI") is not None:
+                config["db_url"] = os.getenv("NEO4J_URI")
+            else:
+                logger.warning("Warning: No Neo4j connection URL provided. Using default: bolt://localhost:7687")
+                config["db_url"] = "bolt://localhost:7687"
+    
+    # parse username
+    if args.username is not None:
+        config["username"] = args.username
+    else:
+        if os.getenv("NEO4J_USERNAME") is not None:
+            config["username"] = os.getenv("NEO4J_USERNAME")
+        else:
+            logger.warning("Warning: No Neo4j username provided. Using default: neo4j")
+            config["username"] = "neo4j"
+    
+    # parse password
+    if args.password is not None:
+        config["password"] = args.password
+    else:
+        if os.getenv("NEO4J_PASSWORD") is not None:
+            config["password"] = os.getenv("NEO4J_PASSWORD")
+        else:
+            logger.warning("Warning: No Neo4j password provided. Using default: password")
+            config["password"] = "password"
+    
+    # parse database
+    if args.database is not None:
+        config["database"] = args.database
+    else:
+        if os.getenv("NEO4J_DATABASE") is not None:
+            config["database"] = os.getenv("NEO4J_DATABASE")
+        else:
+            logger.warning("Warning: No Neo4j database provided. Using default: neo4j")
+            config["database"] = "neo4j"
+    
+    # parse namespace
+    if args.namespace is not None:
+        config["namespace"] = args.namespace
+    else:
+        if os.getenv("NEO4J_NAMESPACE") is not None:
+            config["namespace"] = os.getenv("NEO4J_NAMESPACE")
+        else:
+            logger.info("Info: No namespace provided. No namespace will be used.")
+            config["namespace"] = ""
+    
+    # parse transport
+    if args.transport is not None:
+        config["transport"] = args.transport
+    else:
+        if os.getenv("NEO4J_TRANSPORT") is not None:
+            config["transport"] = os.getenv("NEO4J_TRANSPORT")
+        else:
+            logger.warning("Warning: No transport type provided. Using default: stdio")
+            config["transport"] = "stdio"
+    
+    # parse server host
+    if args.server_host is not None:
+        if config["transport"] == "stdio":
+            logger.warning("Warning: Server host provided, but transport is `stdio`. The `server_host` argument will be set, but ignored.")
+        config["host"] = args.server_host
+    else:
+        if os.getenv("NEO4J_MCP_SERVER_HOST") is not None:
+            if config["transport"] == "stdio":
+                logger.warning("Warning: Server host provided, but transport is `stdio`. The `NEO4J_MCP_SERVER_HOST` environment variable will be set, but ignored.")
+            config["host"] = os.getenv("NEO4J_MCP_SERVER_HOST")
+        elif config["transport"] != "stdio":
+            logger.warning("Warning: No server host provided and transport is not `stdio`. Using default server host: 127.0.0.1")
+            config["host"] = "127.0.0.1"
+        else:
+            logger.info("Info: No server host provided and transport is `stdio`. `server_host` will be None.")
+            config["host"] = None
+     
+    # parse server port
+    if args.server_port is not None:
+        if config["transport"] == "stdio":
+            logger.warning("Warning: Server port provided, but transport is `stdio`. The `server_port` argument will be set, but ignored.")
+        config["port"] = args.server_port
+    else:
+        if os.getenv("NEO4J_MCP_SERVER_PORT") is not None:
+            if config["transport"] == "stdio":
+                logger.warning("Warning: Server port provided, but transport is `stdio`. The `NEO4J_MCP_SERVER_PORT` environment variable will be set, but ignored.")
+            config["port"] = int(os.getenv("NEO4J_MCP_SERVER_PORT"))
+        elif config["transport"] != "stdio":
+            logger.warning("Warning: No server port provided and transport is not `stdio`. Using default server port: 8000")
+            config["port"] = 8000
+        else:
+            logger.info("Info: No server port provided and transport is `stdio`. `server_port` will be None.")
+            config["port"] = None
+    
+    # parse server path
+    if args.server_path is not None:
+        if config["transport"] == "stdio":
+            logger.warning("Warning: Server path provided, but transport is `stdio`. The `server_path` argument will be set, but ignored.")
+        config["path"] = args.server_path
+    else:
+        if os.getenv("NEO4J_MCP_SERVER_PATH") is not None:
+            if config["transport"] == "stdio":
+                logger.warning("Warning: Server path provided, but transport is `stdio`. The `NEO4J_MCP_SERVER_PATH` environment variable will be set, but ignored.")
+            config["path"] = os.getenv("NEO4J_MCP_SERVER_PATH")
+        elif config["transport"] != "stdio":
+            logger.warning("Warning: No server path provided and transport is not `stdio`. Using default server path: /mcp/")
+            config["path"] = "/mcp/"
+        else:
+            logger.info("Info: No server path provided and transport is `stdio`. `server_path` will be None.")
+            config["path"] = None
+    
+    return config

--- a/servers/mcp-neo4j-cypher/tests/unit/test_utils.py
+++ b/servers/mcp-neo4j-cypher/tests/unit/test_utils.py
@@ -1,0 +1,307 @@
+import argparse
+import os
+from unittest.mock import patch
+import pytest
+
+from mcp_neo4j_cypher.utils import process_config
+
+
+@pytest.fixture
+def clean_env():
+    """Fixture to clean environment variables before each test."""
+    env_vars = [
+        "NEO4J_URL", "NEO4J_URI", "NEO4J_USERNAME", "NEO4J_PASSWORD", 
+        "NEO4J_DATABASE", "NEO4J_TRANSPORT", "NEO4J_MCP_SERVER_HOST", 
+        "NEO4J_MCP_SERVER_PORT", "NEO4J_MCP_SERVER_PATH", "NEO4J_NAMESPACE"
+    ]
+    # Store original values
+    original_values = {}
+    for var in env_vars:
+        if var in os.environ:
+            original_values[var] = os.environ[var]
+            del os.environ[var]
+    
+    yield
+    
+    # Restore original values
+    for var, value in original_values.items():
+        os.environ[var] = value
+
+
+@pytest.fixture
+def args_factory():
+    """Factory fixture to create argparse.Namespace objects with default None values."""
+    def _create_args(**kwargs):
+        defaults = {
+            "db_url": None,
+            "username": None,
+            "password": None,
+            "database": None,
+            "namespace": None,
+            "transport": None,
+            "server_host": None,
+            "server_port": None,
+            "server_path": None,
+        }
+        defaults.update(kwargs)
+        return argparse.Namespace(**defaults)
+    return _create_args
+
+
+@pytest.fixture
+def mock_logger():
+    """Fixture to provide a mocked logger."""
+    with patch('mcp_neo4j_cypher.utils.logger') as mock:
+        yield mock
+
+
+@pytest.fixture
+def sample_cli_args(args_factory):
+    """Fixture providing sample CLI arguments."""
+    return args_factory(
+        db_url="bolt://test:7687",
+        username="testuser",
+        password="testpass",
+        database="testdb",
+        transport="http",
+        server_host="localhost",
+        server_port=9000,
+        server_path="/test/",
+        namespace="testnamespace"
+    )
+
+
+@pytest.fixture
+def sample_env_vars():
+    """Fixture providing sample environment variables."""
+    return {
+        "NEO4J_URL": "bolt://env:7687",
+        "NEO4J_USERNAME": "envuser",
+        "NEO4J_PASSWORD": "envpass",
+        "NEO4J_DATABASE": "envdb",
+        "NEO4J_TRANSPORT": "sse",
+        "NEO4J_MCP_SERVER_HOST": "envhost",
+        "NEO4J_MCP_SERVER_PORT": "8080",
+        "NEO4J_MCP_SERVER_PATH": "/env/",
+        "NEO4J_NAMESPACE": "envnamespace"
+    }
+
+
+@pytest.fixture
+def set_env_vars(sample_env_vars):
+    """Fixture to set environment variables and clean up after test."""
+    for key, value in sample_env_vars.items():
+        os.environ[key] = value
+    yield sample_env_vars
+    # Cleanup handled by clean_env fixture
+
+
+@pytest.fixture
+def expected_defaults():
+    """Fixture providing expected default configuration values."""
+    return {
+        "db_url": "bolt://localhost:7687",
+        "username": "neo4j",
+        "password": "password",
+        "database": "neo4j",
+        "transport": "stdio",
+        "host": None,
+        "port": None,
+        "path": None,
+        "namespace": "",
+    }
+
+
+def test_all_cli_args_provided(clean_env, sample_cli_args):
+    """Test when all CLI arguments are provided."""
+    config = process_config(sample_cli_args)
+    
+    assert config["db_url"] == "bolt://test:7687"
+    assert config["username"] == "testuser"
+    assert config["password"] == "testpass"
+    assert config["database"] == "testdb"
+    assert config["transport"] == "http"
+    assert config["host"] == "localhost"
+    assert config["port"] == 9000
+    assert config["path"] == "/test/"
+    assert config["namespace"] == "testnamespace"
+
+
+def test_all_env_vars_provided(clean_env, set_env_vars, args_factory):
+    """Test when all environment variables are provided."""
+    args = args_factory()
+    config = process_config(args)
+    
+    assert config["db_url"] == "bolt://env:7687"
+    assert config["username"] == "envuser"
+    assert config["password"] == "envpass"
+    assert config["database"] == "envdb"
+    assert config["transport"] == "sse"
+    assert config["host"] == "envhost"
+    assert config["port"] == 8080
+    assert config["path"] == "/env/"
+    assert config["namespace"] == "envnamespace"
+
+def test_cli_args_override_env_vars(clean_env, args_factory):
+    """Test that CLI arguments take precedence over environment variables."""
+    os.environ["NEO4J_URL"] = "bolt://env:7687"
+    os.environ["NEO4J_USERNAME"] = "envuser"
+    
+    args = args_factory(
+        db_url="bolt://cli:7687",
+        username="cliuser"
+    )
+    
+    config = process_config(args)
+    
+    assert config["db_url"] == "bolt://cli:7687"
+    assert config["username"] == "cliuser"
+
+
+def test_neo4j_uri_fallback(clean_env, args_factory):
+    """Test NEO4J_URI fallback when NEO4J_URL is not set."""
+    os.environ["NEO4J_URI"] = "bolt://uri:7687"
+    
+    args = args_factory()
+    config = process_config(args)
+    
+    assert config["db_url"] == "bolt://uri:7687"
+
+
+def test_default_values_with_warnings(clean_env, args_factory, expected_defaults, mock_logger):
+    """Test default values are used and warnings are logged when nothing is provided."""
+    args = args_factory()
+    config = process_config(args)
+    
+    for key, expected_value in expected_defaults.items():
+        assert config[key] == expected_value
+    
+    # Check that warnings were logged
+    warning_calls = [call for call in mock_logger.warning.call_args_list]
+    assert len(warning_calls) == 5  # 5 warnings: neo4j uri, user, password, database, transport
+
+
+def test_stdio_transport_ignores_server_config(clean_env, args_factory, mock_logger):
+    """Test that stdio transport ignores server host/port/path and logs warnings."""
+    args = args_factory(
+        transport="stdio",
+        server_host="localhost",
+        server_port=8000,
+        server_path="/test/"
+    )
+    
+    config = process_config(args)
+    
+    assert config["transport"] == "stdio"
+    assert config["host"] == "localhost"  # Set but ignored
+    assert config["port"] == 8000  # Set but ignored
+    assert config["path"] == "/test/"  # Set but ignored
+    
+    # Check that warnings were logged for ignored server config
+    warning_calls = [call.args[0] for call in mock_logger.warning.call_args_list]
+    stdio_warnings = [msg for msg in warning_calls if "stdio" in msg and "ignored" in msg]
+    assert len(stdio_warnings) == 3  # host, port, path warnings
+
+
+def test_stdio_transport_env_vars_ignored(clean_env, args_factory, mock_logger):
+    """Test that stdio transport ignores environment variables for server config."""
+    os.environ["NEO4J_TRANSPORT"] = "stdio"
+    os.environ["NEO4J_MCP_SERVER_HOST"] = "envhost"
+    os.environ["NEO4J_MCP_SERVER_PORT"] = "9000"
+    os.environ["NEO4J_MCP_SERVER_PATH"] = "/envpath/"
+    
+    args = args_factory()
+    config = process_config(args)
+    
+    assert config["transport"] == "stdio"
+    assert config["host"] == "envhost"  # Set but ignored
+    assert config["port"] == 9000  # Set but ignored
+    assert config["path"] == "/envpath/"  # Set but ignored
+    
+    # Check that warnings were logged for ignored env vars
+    warning_calls = [call.args[0] for call in mock_logger.warning.call_args_list]
+    stdio_warnings = [msg for msg in warning_calls if "stdio" in msg and "environment variable" in msg]
+    assert len(stdio_warnings) == 3
+
+
+def test_non_stdio_transport_uses_defaults(clean_env, args_factory, mock_logger):
+    """Test that non-stdio transport uses default server config when not provided."""
+    args = args_factory(transport="http")
+    config = process_config(args)
+    
+    assert config["transport"] == "http"
+    assert config["host"] == "127.0.0.1"
+    assert config["port"] == 8000
+    assert config["path"] == "/mcp/"
+    
+    # Check that warnings were logged for using defaults
+    warning_calls = [call.args[0] for call in mock_logger.warning.call_args_list]
+    default_warnings = [msg for msg in warning_calls if "Using default" in msg]
+    assert len(default_warnings) >= 3  # host, port, path defaults
+
+
+def test_non_stdio_transport_with_server_config(clean_env, args_factory, mock_logger):
+    """Test that non-stdio transport uses provided server config without warnings."""
+    args = args_factory(
+        transport="sse",
+        server_host="myhost",
+        server_port=9999,
+        server_path="/mypath/"
+    )
+    
+    config = process_config(args)
+    
+    assert config["transport"] == "sse"
+    assert config["host"] == "myhost"
+    assert config["port"] == 9999
+    assert config["path"] == "/mypath/"
+    
+    # Should not have warnings about stdio transport
+    warning_calls = [call.args[0] for call in mock_logger.warning.call_args_list]
+    stdio_warnings = [msg for msg in warning_calls if "stdio" in msg]
+    assert len(stdio_warnings) == 0
+
+
+def test_env_var_port_conversion(clean_env, args_factory, mock_logger):
+    """Test that environment variable port is converted to int."""
+    os.environ["NEO4J_MCP_SERVER_PORT"] = "8080"
+    os.environ["NEO4J_TRANSPORT"] = "http"
+    
+    args = args_factory()
+    config = process_config(args)
+    
+    assert config["port"] == 8080
+    assert isinstance(config["port"], int)
+
+
+@pytest.mark.parametrize("transport,expected_host,expected_port,expected_path,expected_warning_count", [
+    ("stdio", None, None, None, 0),  # stdio with no server config
+    ("http", "127.0.0.1", 8000, "/mcp/", 3),  # http with defaults
+    ("sse", "127.0.0.1", 8000, "/mcp/", 3),   # sse with defaults
+])
+def test_mixed_transport_scenarios(clean_env, args_factory, mock_logger, transport, expected_host, expected_port, expected_path, expected_warning_count):
+    """Test various combinations of transport with server config."""
+    args = args_factory(transport=transport)
+    config = process_config(args)
+    
+    assert config["transport"] == transport
+    assert config["host"] == expected_host
+    assert config["port"] == expected_port
+    assert config["path"] == expected_path
+    
+    warning_calls = [call.args[0] for call in mock_logger.warning.call_args_list]
+    server_warnings = [msg for msg in warning_calls if any(
+        keyword in msg for keyword in ["server host", "server port", "server path"]
+    )]
+    assert len(server_warnings) == expected_warning_count, f"Transport {transport} warning count mismatch"
+
+
+def test_info_logging_stdio_transport(clean_env, args_factory, mock_logger):
+    """Test that info messages are logged for stdio transport when appropriate."""
+    args = args_factory(transport="stdio")
+    config = process_config(args)
+    
+    # Check for info messages about stdio transport
+    info_calls = [call.args[0] for call in mock_logger.info.call_args_list]
+    stdio_info = [msg for msg in info_calls if "stdio" in msg]
+    assert len(stdio_info) == 3  # host, port, path info messages


### PR DESCRIPTION
* Add parsing logic to raise warnings if no value provided in cli or env variables
* Uses default config value if appropriate

*note that cli args overwrite env variables*

The following config will log the following to the logs:

```json
{
  "mcpServers": {
  "mcp-cypher": {
    "command": "uv",
    "args": [
      "--directory", "/path/to/server/mcp-neo4j/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher",
      "run", "mcp-neo4j-cypher", "--transport", "stdio"],
      "env": {
        "NEO4J_USERNAME": "neo4j",
        "NEO4J_URI": "bolt://localhost:7687",
        "NEO4J_NAMESPACE": "testnamespace",
        "NEO4J_MCP_SERVER_PATH": "/test-path/",
        "NEO4J_TRANSPORT": "sse"
      }
  }
}
```

Claude Desktop logs: 

```
...
Warning: No Neo4j password provided. Using default: password
Warning: No Neo4j database provided. Using default: neo4j
Warning: Server path provided, but transport is `stdio`. The `NEO4J_MCP_SERVER_PATH` environment variable will be set, but ignored.
...
```
