### PR TITLE
Sanitize embedding-like values from cypher read tool

### DIFF
--- a/servers/mcp-neo4j-cypher/CHANGELOG.md
+++ b/servers/mcp-neo4j-cypher/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 ### Added
+* Added Cypher result sanitation function from Neo4j GraphRAG that removes embedding values from the result
 
 ## v0.3.1
 


### PR DESCRIPTION
Since modern graphs contain text embeddings, we want to avoid feeding them to an LLM if possible since they do not bring any additional value and only pollute the context. We use the functions on each element of the response and not the response itself to allow more that 128 rows in the results, but none of the rows will have values with lists of more than 128 elements.

This function has been in use for 2 years now in langchain, neo4j-graphrag, and llamaIndex, see: https://github.com/neo4j/neo4j-graphrag-python/blob/main/src/neo4j_graphrag/schema.py#L88