### PR TITLE
Introduce Read only mode for MCP Cypher

### DIFF
--- a/servers/mcp-neo4j-cypher/CHANGELOG.md
+++ b/servers/mcp-neo4j-cypher/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 ### Added
+* Add env variable `NEO4J_READ_ONLY` and cli variable `--read-only` to configure tool availability
 
 ## v0.4.0
 

--- a/servers/mcp-neo4j-cypher/Makefile
+++ b/servers/mcp-neo4j-cypher/Makefile
@@ -1,3 +1,8 @@
+format:
+	uv run ruff check --select I . --fix
+	uv run ruff check --fix .
+	uv run ruff format .
+	
 install-dev:
 	uv sync
 

--- a/servers/mcp-neo4j-cypher/README.md
+++ b/servers/mcp-neo4j-cypher/README.md
@@ -38,6 +38,7 @@ The server offers these core tools:
     - `query` (string): The Cypher update query
     - `params` (dictionary, optional): Parameters to pass to the Cypher query
   - Returns: A JSON serialized result summary counter with `{ nodes_updated: number, relationships_created: number, ... }`
+  - **Availability**: May be disabled by supplying --read-only as cli flag or `NEO4J_READ_ONLY=true` environment variable
 
 #### 🕸️ Schema Tools
 

--- a/servers/mcp-neo4j-cypher/README.md
+++ b/servers/mcp-neo4j-cypher/README.md
@@ -405,6 +405,7 @@ docker run --rm -p 8000:8000 \
 | `NEO4J_MCP_SERVER_ALLOWED_HOSTS`   | `localhost,127.0.0.1`                   | Comma-separated list of allowed hosts (DNS rebinding protection) |
 | `NEO4J_RESPONSE_TOKEN_LIMIT`       | _(none)_                                | Maximum tokens for read query responses            |
 | `NEO4J_READ_TIMEOUT`               | `30`                                    | Timeout in seconds for read queries                |
+| `NEO4J_READ_ONLY`                  | `false`                                 | Allow only read-only queries (true/false)          |
 
 ### 🌐 SSE Transport for Legacy Web Access
 

--- a/servers/mcp-neo4j-cypher/manifest.json
+++ b/servers/mcp-neo4j-cypher/manifest.json
@@ -160,6 +160,14 @@
       "default": 30,
       "required": false,
       "sensitive": false
+    },
+    "read_only": {
+      "type": "boolean",
+      "title": "Read Only Mode",
+      "description": "Allow only read-only queries, no write operations permitted.",
+      "default": false,
+      "required": false,
+      "sensitive": false
     }
   }
 }

--- a/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/__init__.py
+++ b/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/__init__.py
@@ -32,10 +32,16 @@ def main():
         help="Allowed hosts for DNS rebinding protection on remote servers(comma-separated list)",
     )
     parser.add_argument(
-        "--read-timeout", 
-        type=int, 
-        default=None, 
-        help="Timeout in seconds for read queries (default: 30)"
+        "--read-timeout",
+        type=int,
+        default=None,
+        help="Timeout in seconds for read queries (default: 30)",
+    )
+    parser.add_argument(
+        "--read-only",
+        type=bool,
+        default=False,
+        help="Allow only read-only queries (default: False)",
     )
     parser.add_argument("--token-limit", default=None, help="Response token limit")
 

--- a/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/__init__.py
+++ b/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/__init__.py
@@ -39,8 +39,7 @@ def main():
     )
     parser.add_argument(
         "--read-only",
-        type=bool,
-        default=False,
+        action="store_true",
         help="Allow only read-only queries (default: False)",
     )
     parser.add_argument("--token-limit", default=None, help="Response token limit")

--- a/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/server.py
+++ b/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/server.py
@@ -51,7 +51,7 @@ def create_mcp_server(
 
     namespace_prefix = _format_namespace(namespace)
     allow_writes = not read_only
-    
+
     @mcp.tool(
         name=namespace_prefix + "get_neo4j_schema",
         annotations=ToolAnnotations(
@@ -211,8 +211,6 @@ def create_mcp_server(
             logger.error(f"Error executing read query: {e}\n{query}\n{params}")
             raise ToolError(f"Error: {e}\n{query}\n{params}")
 
-
-
     @mcp.tool(
         name=namespace_prefix + "write_neo4j_cypher",
         annotations=ToolAnnotations(
@@ -252,9 +250,7 @@ def create_mcp_server(
             )
 
         except Neo4jError as e:
-            logger.error(
-                f"Neo4j Error executing write query: {e}\n{query}\n{params}"
-            )
+            logger.error(f"Neo4j Error executing write query: {e}\n{query}\n{params}")
             raise ToolError(f"Neo4j Error: {e}\n{query}\n{params}")
 
         except Exception as e:

--- a/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/utils.py
+++ b/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/utils.py
@@ -12,7 +12,7 @@ logger.setLevel(logging.INFO)
 def parse_boolean_safely(value: Union[str, bool]) -> bool:
     """
     Safely parse a string value to boolean with strict validation.
-    
+
     Parameters
     ----------
     value : Union[str, bool]
@@ -34,11 +34,12 @@ def parse_boolean_safely(value: Union[str, bool]) -> bool:
         elif normalized == "false":
             return False
         else:
-            raise ValueError(f"Invalid boolean value: '{value}'. Must be 'true' or 'false'")
+            raise ValueError(
+                f"Invalid boolean value: '{value}'. Must be 'true' or 'false'"
+            )
     # we shouldn't get here, but just in case
     else:
         raise ValueError(f"Invalid boolean value: '{value}'. Must be 'true' or 'false'")
-
 
 
 def process_config(args: argparse.Namespace) -> dict[str, Union[str, int, None]]:
@@ -281,7 +282,9 @@ def process_config(args: argparse.Namespace) -> dict[str, Union[str, int, None]]
     # parse read-only
     if args.read_only:
         config["read_only"] = True
-        logger.info(f"Info: Read-only mode set to {config['read_only']} via command line argument.")
+        logger.info(
+            f"Info: Read-only mode set to {config['read_only']} via command line argument."
+        )
     elif os.getenv("NEO4J_READ_ONLY") is not None:
         config["read_only"] = parse_boolean_safely(os.getenv("NEO4J_READ_ONLY"))
         logger.info(

--- a/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/utils.py
+++ b/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/utils.py
@@ -173,14 +173,17 @@ def process_config(args: argparse.Namespace) -> dict[str, Union[str, int, None]]
     # parse allow origins
     if args.allow_origins is not None:
         # Handle comma-separated string from CLI
-     
-        config["allow_origins"] = [origin.strip() for origin in args.allow_origins.split(",") if origin.strip()]
+
+        config["allow_origins"] = [
+            origin.strip() for origin in args.allow_origins.split(",") if origin.strip()
+        ]
 
     else:
         if os.getenv("NEO4J_MCP_SERVER_ALLOW_ORIGINS") is not None:
             # split comma-separated string into list
             config["allow_origins"] = [
-                origin.strip() for origin in os.getenv("NEO4J_MCP_SERVER_ALLOW_ORIGINS", "").split(",") 
+                origin.strip()
+                for origin in os.getenv("NEO4J_MCP_SERVER_ALLOW_ORIGINS", "").split(",")
                 if origin.strip()
             ]
         else:
@@ -192,13 +195,16 @@ def process_config(args: argparse.Namespace) -> dict[str, Union[str, int, None]]
     # parse allowed hosts for DNS rebinding protection
     if args.allowed_hosts is not None:
         # Handle comma-separated string from CLI
-        config["allowed_hosts"] = [host.strip() for host in args.allowed_hosts.split(",") if host.strip()]
-      
+        config["allowed_hosts"] = [
+            host.strip() for host in args.allowed_hosts.split(",") if host.strip()
+        ]
+
     else:
         if os.getenv("NEO4J_MCP_SERVER_ALLOWED_HOSTS") is not None:
             # split comma-separated string into list
             config["allowed_hosts"] = [
-                host.strip() for host in os.getenv("NEO4J_MCP_SERVER_ALLOWED_HOSTS", "").split(",") 
+                host.strip()
+                for host in os.getenv("NEO4J_MCP_SERVER_ALLOWED_HOSTS", "").split(",")
                 if host.strip()
             ]
         else:
@@ -206,7 +212,7 @@ def process_config(args: argparse.Namespace) -> dict[str, Union[str, int, None]]
                 "Info: No allowed hosts provided. Defaulting to secure mode - only localhost and 127.0.0.1 allowed."
             )
             config["allowed_hosts"] = ["localhost", "127.0.0.1"]
-            
+
     # parse token limit
     if args.token_limit is not None:
         config["token_limit"] = args.token_limit
@@ -232,11 +238,28 @@ def process_config(args: argparse.Namespace) -> dict[str, Union[str, int, None]]
                 )
                 config["read_timeout"] = config["read_timeout"]
             except ValueError:
-                logger.warning("Warning: Invalid read timeout provided. Using default: 30 seconds")
+                logger.warning(
+                    "Warning: Invalid read timeout provided. Using default: 30 seconds"
+                )
                 config["read_timeout"] = 30
         else:
             logger.info("Info: No read timeout provided. Using default: 30 seconds")
             config["read_timeout"] = 30
+    # parse read-only
+    if args.read_only is not None:
+        config["read_only"] = args.read_only
+    else:
+        if os.getenv("NEO4J_READ_ONLY") is not None:
+            # Cast string env var to boolean
+            config["read_only"] = os.getenv("NEO4J_READ_ONLY").lower() in (
+                "true",
+                "yes",
+            )
+        else:
+            logger.info(
+                "Info: No read-only setting provided. Write queries will be allowed."
+            )
+            config["read_only"] = False
 
     return config
 
@@ -294,6 +317,7 @@ def _value_sanitize(d: Any, list_limit: int = 128) -> Any:
             return None
     else:
         return d
+
 
 def _truncate_string_to_tokens(
     text: str, token_limit: int, model: str = "gpt-4"

--- a/servers/mcp-neo4j-cypher/tests/integration/conftest.py
+++ b/servers/mcp-neo4j-cypher/tests/integration/conftest.py
@@ -271,7 +271,6 @@ async def http_server_custom_hosts(setup: Neo4jContainer):
         await process.wait()
 
 
-
 @pytest_asyncio.fixture
 async def http_server_read_only(setup: Neo4jContainer):
     """Start the MCP server in HTTP mode with read-only enabled."""

--- a/servers/mcp-neo4j-cypher/tests/integration/conftest.py
+++ b/servers/mcp-neo4j-cypher/tests/integration/conftest.py
@@ -269,3 +269,52 @@ async def http_server_custom_hosts(setup: Neo4jContainer):
     except asyncio.TimeoutError:
         process.kill()
         await process.wait()
+
+
+
+@pytest_asyncio.fixture
+async def http_server_read_only(setup: Neo4jContainer):
+    """Start the MCP server in HTTP mode with read-only enabled."""
+    # Start server process in HTTP mode with read-only
+    process = await asyncio.create_subprocess_exec(
+        "uv",
+        "run",
+        "mcp-neo4j-cypher",
+        "--transport",
+        "http",
+        "--server-host",
+        "127.0.0.1",
+        "--server-port",
+        "8005",
+        "--read-only",
+        "--db-url",
+        setup.get_connection_url(),
+        "--username",
+        setup.username,
+        "--password",
+        setup.password,
+        env=os.environ.copy(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=os.getcwd(),
+    )
+
+    # Wait for server to start
+    await asyncio.sleep(3)
+
+    # Check if process is still running
+    if process.returncode is not None:
+        stdout, stderr = await process.communicate()
+        raise RuntimeError(
+            f"Read-only server failed to start. stdout: {stdout.decode()}, stderr: {stderr.decode()}"
+        )
+
+    yield process
+
+    # Cleanup
+    try:
+        process.terminate()
+        await asyncio.wait_for(process.wait(), timeout=5.0)
+    except asyncio.TimeoutError:
+        process.kill()
+        await process.wait()

--- a/servers/mcp-neo4j-cypher/tests/integration/test_http_transport_IT.py
+++ b/servers/mcp-neo4j-cypher/tests/integration/test_http_transport_IT.py
@@ -98,7 +98,7 @@ async def test_http_write_tool_call_read_only_mode(http_server_read_only):
                 "method": "tools/call",
                 "params": {
                     "name": "write_neo4j_cypher",
-                    "arguments": {"query": "CREATE (n:Test {name: 'test'}) RETURN n"}
+                    "arguments": {"query": "CREATE (n:Test {name: 'test'}) RETURN n"},
                 },
             },
             headers={
@@ -133,7 +133,7 @@ async def test_http_read_tool_call_read_only_mode(http_server_read_only):
                 "method": "tools/call",
                 "params": {
                     "name": "read_neo4j_cypher",
-                    "arguments": {"query": "MATCH (n) RETURN count(n) as total"}
+                    "arguments": {"query": "MATCH (n) RETURN count(n) as total"},
                 },
             },
             headers={

--- a/servers/mcp-neo4j-cypher/tests/integration/test_server_tools_IT.py
+++ b/servers/mcp-neo4j-cypher/tests/integration/test_server_tools_IT.py
@@ -1,11 +1,9 @@
 import json
 from typing import Any
-from unittest.mock import patch
 
 import pytest
 from fastmcp.exceptions import ToolError
 from fastmcp.server import FastMCP
-from neo4j.exceptions import Neo4jError
 
 
 @pytest.mark.asyncio(loop_scope="function")
@@ -59,7 +57,9 @@ async def test_read_neo4j_cypher(mcp_server: FastMCP, init_data: Any):
 
 
 @pytest.mark.asyncio(loop_scope="function")
-async def test_read_query_timeout_with_slow_query(mcp_server_short_timeout: FastMCP, clear_data: Any):
+async def test_read_query_timeout_with_slow_query(
+    mcp_server_short_timeout: FastMCP, clear_data: Any
+):
     """Test that read queries timeout appropriately with a slow query."""
     # Create a query that should take longer than 0.01 seconds
     slow_query = """
@@ -69,9 +69,9 @@ async def test_read_query_timeout_with_slow_query(mcp_server_short_timeout: Fast
     WHERE x % 2 = 0
     RETURN count(x) AS result
     """
-    
+
     tool = await mcp_server_short_timeout.get_tool("read_neo4j_cypher")
-    
+
     # The query might timeout and raise a ToolError, or it might complete very fast
     # Let's just verify the server handles it without crashing
     try:
@@ -87,15 +87,17 @@ async def test_read_query_timeout_with_slow_query(mcp_server_short_timeout: Fast
 
 
 @pytest.mark.asyncio(loop_scope="function")
-async def test_read_query_with_normal_timeout_succeeds(mcp_server: FastMCP, init_data: Any):
+async def test_read_query_with_normal_timeout_succeeds(
+    mcp_server: FastMCP, init_data: Any
+):
     """Test that normal queries succeed with reasonable timeout."""
     query = "MATCH (p:Person) RETURN p.name AS name ORDER BY name"
-    
+
     tool = await mcp_server.get_tool("read_neo4j_cypher")
     response = await tool.run(dict(query=query))
-    
+
     result = json.loads(response.content[0].text)
-    
+
     # Should succeed and return expected results
     assert len(result) == 3
     assert result[0]["name"] == "Alice"
@@ -107,7 +109,7 @@ async def test_read_query_with_normal_timeout_succeeds(mcp_server: FastMCP, init
 async def test_schema_query_timeout(mcp_server_short_timeout: FastMCP):
     """Test that schema queries also respect timeout settings."""
     tool = await mcp_server_short_timeout.get_tool("get_neo4j_schema")
-    
+
     # Schema query should typically be fast, but with very short timeout it might timeout
     # depending on the database state. Let's just verify it doesn't crash
     try:
@@ -122,17 +124,19 @@ async def test_schema_query_timeout(mcp_server_short_timeout: FastMCP):
         assert "Neo4j Error" in error_message or "timeout" in error_message.lower()
 
 
-@pytest.mark.asyncio(loop_scope="function") 
-async def test_write_query_no_timeout(mcp_server_short_timeout: FastMCP, clear_data: Any):
+@pytest.mark.asyncio(loop_scope="function")
+async def test_write_query_no_timeout(
+    mcp_server_short_timeout: FastMCP, clear_data: Any
+):
     """Test that write queries are not subject to timeout restrictions."""
     # Write queries should not be affected by read_timeout
     query = "CREATE (n:TimeoutTest {name: 'test', created: timestamp()}) RETURN n.name"
-    
+
     tool = await mcp_server_short_timeout.get_tool("write_neo4j_cypher")
     response = await tool.run(dict(query=query))
-    
+
     result = json.loads(response.content[0].text)
-    
+
     # Write operation should succeed regardless of short timeout
     assert "nodes_created" in result
     assert result["nodes_created"] == 1
@@ -142,14 +146,16 @@ async def test_write_query_no_timeout(mcp_server_short_timeout: FastMCP, clear_d
 async def test_timeout_configuration_passed_correctly(async_neo4j_driver):
     """Test that timeout configuration is properly passed to the server."""
     from mcp_neo4j_cypher.server import create_mcp_server
-    
+
     # Create servers with different timeout values
     mcp_30s = create_mcp_server(async_neo4j_driver, "neo4j", read_timeout=30)
     mcp_60s = create_mcp_server(async_neo4j_driver, "neo4j", read_timeout=60)
-    
+
     # Both should be created successfully (configuration test)
     assert mcp_30s is not None
     assert mcp_60s is not None
-    
+
     # The actual timeout values are used internally in Query objects,
     # so this test mainly verifies the parameter is accepted without error
+
+

--- a/servers/mcp-neo4j-cypher/tests/integration/test_server_tools_IT.py
+++ b/servers/mcp-neo4j-cypher/tests/integration/test_server_tools_IT.py
@@ -157,5 +157,3 @@ async def test_timeout_configuration_passed_correctly(async_neo4j_driver):
 
     # The actual timeout values are used internally in Query objects,
     # so this test mainly verifies the parameter is accepted without error
-
-

--- a/servers/mcp-neo4j-cypher/tests/unit/test_utils.py
+++ b/servers/mcp-neo4j-cypher/tests/unit/test_utils.py
@@ -5,7 +5,11 @@ from unittest.mock import patch
 import pytest
 import tiktoken
 
-from mcp_neo4j_cypher.utils import _truncate_string_to_tokens, process_config, parse_boolean_safely
+from mcp_neo4j_cypher.utils import (
+    _truncate_string_to_tokens,
+    parse_boolean_safely,
+    process_config,
+)
 
 
 @pytest.fixture

--- a/servers/mcp-neo4j-cypher/tests/unit/test_utils.py
+++ b/servers/mcp-neo4j-cypher/tests/unit/test_utils.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 import tiktoken
 
-from mcp_neo4j_cypher.utils import process_config, _truncate_string_to_tokens
+from mcp_neo4j_cypher.utils import _truncate_string_to_tokens, process_config, parse_boolean_safely
 
 
 @pytest.fixture
@@ -26,6 +26,7 @@ def clean_env():
         "NEO4J_NAMESPACE",
         "NEO4J_READ_TIMEOUT",
         "NEO4J_RESPONSE_TOKEN_LIMIT",
+        "NEO4J_READ_ONLY",
     ]
     # Store original values
     original_values = {}
@@ -60,6 +61,7 @@ def args_factory():
             "allowed_hosts": None,
             "read_timeout": None,
             "token_limit": None,
+            "read_only": None,
         }
         defaults.update(kwargs)
         return argparse.Namespace(**defaults)
@@ -431,11 +433,12 @@ def test_allow_origins_wildcard(clean_env, args_factory):
 
     assert config["allow_origins"] == [wildcard_origins]
 
+
 def test_read_timeout_cli_arg(clean_env, args_factory):
     """Test that read_timeout CLI argument is properly processed."""
     args = args_factory(read_timeout=60)
     config = process_config(args)
-    
+
     assert config["read_timeout"] == 60
 
 
@@ -445,48 +448,52 @@ def test_read_timeout_env_var(clean_env, args_factory):
 
     args = args_factory()
     config = process_config(args)
-    
+
     assert config["read_timeout"] == 90
+
 
 def test_token_limit_cli_arg(clean_env, args_factory):
     """Test that token_limit CLI argument is processed correctly."""
     args = args_factory(token_limit=5000)
     config = process_config(args)
-    
+
     assert config["token_limit"] == 5000
 
 
 def test_token_limit_env_var(clean_env, args_factory):
     """Test that token_limit environment variable is processed correctly."""
     os.environ["NEO4J_RESPONSE_TOKEN_LIMIT"] = "3000"
-    
+
     args = args_factory()
     config = process_config(args)
-    
+
     assert config["token_limit"] == 3000
 
 
 def test_read_timeout_cli_overrides_env(clean_env, args_factory):
     """Test that CLI read_timeout argument overrides environment variable."""
     os.environ["NEO4J_READ_TIMEOUT"] = "90"
-    
+
     args = args_factory(read_timeout=120)
     config = process_config(args)
-    
+
     assert config["read_timeout"] == 120
+
 
 def test_read_timeout_invalid_env_var(clean_env, args_factory, mock_logger):
     """Test that invalid read_timeout environment variable is handled."""
     os.environ["NEO4J_READ_TIMEOUT"] = "a"
-    
+
     args = args_factory()
     config = process_config(args)
-    
+
     assert config["read_timeout"] == 30
-    
+
     # Check that warning message was logged about invalid value
     warning_calls = [call.args[0] for call in mock_logger.warning.call_args_list]
-    invalid_timeout_warning = [msg for msg in warning_calls if "Invalid read timeout" in msg]
+    invalid_timeout_warning = [
+        msg for msg in warning_calls if "Invalid read timeout" in msg
+    ]
     assert len(invalid_timeout_warning) == 1
 
 
@@ -494,12 +501,14 @@ def test_read_timeout_default_value(clean_env, args_factory, mock_logger):
     """Test that default read_timeout is used when not specified."""
     args = args_factory()
     config = process_config(args)
-    
+
     assert config["read_timeout"] == 30
-    
+
     # Check that info message was logged about default
     info_calls = [call.args[0] for call in mock_logger.info.call_args_list]
-    timeout_info = [msg for msg in info_calls if "read timeout" in msg and "default" in msg]
+    timeout_info = [
+        msg for msg in info_calls if "read timeout" in msg and "default" in msg
+    ]
     assert len(timeout_info) == 1
     assert config["read_timeout"] == 30
 
@@ -508,9 +517,9 @@ def test_token_limit_default_none(clean_env, args_factory, mock_logger):
     """Test that token_limit defaults to None when not provided."""
     args = args_factory()
     config = process_config(args)
-    
+
     assert config["token_limit"] is None
-    
+
     # Check info message
     info_calls = [call.args[0] for call in mock_logger.info.call_args_list]
     token_limit_info = [msg for msg in info_calls if "token limit" in msg]
@@ -520,81 +529,85 @@ def test_token_limit_default_none(clean_env, args_factory, mock_logger):
 def test_token_limit_cli_overrides_env(clean_env, args_factory):
     """Test that CLI token_limit takes precedence over environment variable."""
     os.environ["NEO4J_RESPONSE_TOKEN_LIMIT"] = "2000"
-    
+
     args = args_factory(token_limit=4000)
     config = process_config(args)
-    
+
     assert config["token_limit"] == 4000
 
 
 # Token truncation tests
 
+
 class TestTruncateStringToTokens:
     """Test cases for _truncate_string_to_tokens function."""
-    
+
     def test_short_string_not_truncated(self):
         """Test that strings below token limit are not truncated."""
         text = "Hello, world!"
         token_limit = 100
-        
+
         result = _truncate_string_to_tokens(text, token_limit)
-        
+
         assert result == text
-    
+
     def test_string_exactly_at_limit_not_truncated(self):
         """Test that strings exactly at token limit are not truncated."""
         text = "This is a test string."
         encoding = tiktoken.encoding_for_model("gpt-4")
         tokens = encoding.encode(text)
         token_limit = len(tokens)
-        
+
         result = _truncate_string_to_tokens(text, token_limit)
-        
+
         assert result == text
-    
+
     def test_long_string_truncated(self):
         """Test that strings exceeding token limit are truncated."""
-        text = "This is a very long string that should definitely exceed the token limit. " * 10
+        text = (
+            "This is a very long string that should definitely exceed the token limit. "
+            * 10
+        )
         token_limit = 20
-        
+
         result = _truncate_string_to_tokens(text, token_limit)
-        
+
         # Verify it's shorter than original
         assert len(result) < len(text)
-        
+
         # Verify it's within token limit
         encoding = tiktoken.encoding_for_model("gpt-4")
         result_tokens = encoding.encode(result)
         assert len(result_tokens) <= token_limit
-    
+
     def test_empty_string_handling(self):
         """Test handling of empty strings."""
         text = ""
         token_limit = 10
-        
+
         result = _truncate_string_to_tokens(text, token_limit)
-        
+
         assert result == ""
-    
+
     def test_single_character_handling(self):
         """Test handling of single characters."""
         text = "A"
         token_limit = 10
-        
+
         result = _truncate_string_to_tokens(text, token_limit)
-        
+
         assert result == "A"
-    
+
     def test_zero_token_limit(self):
         """Test behavior with zero token limit."""
         text = "Hello, world!"
         token_limit = 0
-        
+
         result = _truncate_string_to_tokens(text, token_limit)
-        
+
         # Should return empty string when limit is 0
         assert result == ""
-    
+
     def test_json_data_truncation(self):
         """Test truncation of JSON-like data typical of Neo4j responses."""
         json_data = """[
@@ -604,39 +617,120 @@ class TestTruncateStringToTokens:
             {"name": "Diana", "age": 28, "city": "Seattle", "occupation": "Developer"}
         ]"""
         token_limit = 30
-        
+
         result = _truncate_string_to_tokens(json_data, token_limit)
-        
+
         # Verify truncation occurred
         assert len(result) < len(json_data)
-        
+
         # Verify token limit respected
         encoding = tiktoken.encoding_for_model("gpt-4")
         result_tokens = encoding.encode(result)
         assert len(result_tokens) <= token_limit
-    
+
     def test_unicode_handling(self):
         """Test handling of unicode characters."""
         text = "Hello 🌍! This has unicode: café, naïve, 北京"
         token_limit = 10
-        
+
         result = _truncate_string_to_tokens(text, token_limit)
-        
+
         # Should handle unicode properly
         encoding = tiktoken.encoding_for_model("gpt-4")
         result_tokens = encoding.encode(result)
         assert len(result_tokens) <= token_limit
-        
+
         # Result should be valid unicode
         assert isinstance(result, str)
-    
+
     def test_large_token_limit_no_truncation(self):
         """Test with token limit much larger than text."""
         text = "Short text."
         token_limit = 10000  # Very large limit
-        
+
         result = _truncate_string_to_tokens(text, token_limit)
-        
+
         assert result == text
-    
-    
+
+
+# Boolean parsing tests
+
+
+class TestParseBooleanSafely:
+    """Test cases for parse_boolean_safely function."""
+
+    def test_bool_inputs(self):
+        """Test boolean inputs."""
+        assert parse_boolean_safely(True) is True
+        assert parse_boolean_safely(False) is False
+
+    def test_string_true_variations(self):
+        """Test string 'true' variations."""
+        assert parse_boolean_safely("true") is True
+        assert parse_boolean_safely("TRUE") is True
+        assert parse_boolean_safely("  true  ") is True
+
+    def test_string_false_variations(self):
+        """Test string 'false' variations."""
+        assert parse_boolean_safely("false") is False
+        assert parse_boolean_safely("FALSE") is False
+        assert parse_boolean_safely("  false  ") is False
+
+    def test_invalid_strings(self):
+        """Test invalid string values raise ValueError."""
+        invalid_values = ["yes", "no", "1", "0", "", "random"]
+        for value in invalid_values:
+            with pytest.raises(ValueError, match="Invalid boolean value"):
+                parse_boolean_safely(value)
+
+    def test_invalid_types(self):
+        """Test invalid types raise ValueError."""
+        invalid_values = [None, 1, [], {}]
+        for value in invalid_values:
+            with pytest.raises(ValueError, match="Invalid boolean value"):
+                parse_boolean_safely(value)
+
+
+# Read-only configuration tests
+
+
+def test_read_only_cli_args(clean_env, args_factory):
+    """Test read-only mode via CLI arguments."""
+    # Boolean values
+    assert process_config(args_factory(read_only=True))["read_only"] is True
+    assert process_config(args_factory(read_only=False))["read_only"] is False
+
+    # String values
+    assert process_config(args_factory(read_only="true"))["read_only"] is True
+    assert process_config(args_factory(read_only="FALSE"))["read_only"] is False
+
+
+def test_read_only_env_vars(clean_env, args_factory):
+    """Test read-only mode via environment variables."""
+    os.environ["NEO4J_READ_ONLY"] = "true"
+    assert process_config(args_factory())["read_only"] is True
+
+    os.environ["NEO4J_READ_ONLY"] = "FALSE"
+    assert process_config(args_factory())["read_only"] is False
+
+
+def test_read_only_invalid_values(clean_env, args_factory):
+    """Test read-only mode with invalid values raises ValueError."""
+    # CLI invalid
+    with pytest.raises(ValueError):
+        process_config(args_factory(read_only="yes"))
+
+    # Environment invalid
+    os.environ["NEO4J_READ_ONLY"] = "1"
+    with pytest.raises(ValueError):
+        process_config(args_factory())
+
+
+def test_read_only_defaults_and_precedence(clean_env, args_factory):
+    """Test read-only defaults and CLI precedence."""
+    # Default is False
+    assert process_config(args_factory())["read_only"] is False
+
+    # CLI overrides environment
+    os.environ["NEO4J_READ_ONLY"] = "true"
+    assert process_config(args_factory(read_only=False))["read_only"] is False


### PR DESCRIPTION
While some clients allow to disable the writing tool, it is still exposed via mcp server and vulnerable to malicious actors. Therefore, we introduce a new config called `read_only` and `NEO4J_READ_ONLY` to be able disable the write tool.

Also ran ruff format, so some additional formatter changes