### PR TITLE
Add Claude Code plugin support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "mcp-neo4j",
+  "version": "1.0.0",
+  "description": "Neo4j MCP servers for graph database operations, memory management, Aura cloud management, and data modeling",
+  "mcpServers": {
+    "mcp-neo4j-cloud-aura-api": {
+      "command": "uvx",
+      "args": ["mcp-neo4j-aura-manager"]
+    },
+    "mcp-neo4j-cypher": {
+      "command": "uvx",
+      "args": ["mcp-neo4j-cypher"]
+    },
+    "mcp-neo4j-data-modeling": {
+      "command": "uvx",
+      "args": ["mcp-neo4j-data-modeling"]
+    },
+    "mcp-neo4j-memory": {
+      "command": "uvx",
+      "args": ["mcp-neo4j-memory"]
+    }
+  }
+}


### PR DESCRIPTION
# Description

Add Claude Code plugin support to enable easy installation and use of Neo4j MCP servers through the Claude Code plugin system.

This PR adds a `.claude-plugin/plugin.json` manifest file that configures all four MCP servers (Cypher, Memory, Aura API, Data Modeling) to work seamlessly with Claude Code's plugin system.

## Installation

Users can install this plugin via the pleaseai marketplace:

```bash
# Add the pleaseai marketplace
/plugin marketplace add pleaseai/claude-code-plugins

# Install the mcp-neo4j plugin
/plugin install mcp-neo4j@pleaseai
```

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update
- [ ] Project configuration change

## Complexity
- [x] LOW
- [ ] MEDIUM
- [ ] HIGH

This is a low-complexity change that only adds a new configuration file without modifying any existing code or functionality.

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests

Manual testing performed:
- Verified plugin.json follows Claude Code plugin specification
- Confirmed all four MCP servers are correctly configured
- Validated JSON syntax and structure

# Checklist

- [x] Documentation has been updated (added plugin.json)
- [ ] Unit tests have been updated (N/A - configuration only)
- [ ] Integration tests have been updated (N/A - configuration only)
- [ ] Server has been tested in an MCP application (to be tested after merge)
- [ ] CHANGELOG.md updated if appropriate (can be added if needed)