### PR TITLE
data modeling - short tool names 

### DIFF
--- a/servers/mcp-neo4j-data-modeling/CHANGELOG.md
+++ b/servers/mcp-neo4j-data-modeling/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next
 
 ### Fixed
+* Shorten tool name `export_to_neo4j_python_graphrag_package_schema` to `export_to_neo4j_graphrag_pkg_schema` to be under 60 characters including the default server name.
+* Shorten tool name `load_from_neo4j_python_graphrag_package_schema` to `load_from_neo4j_graphrag_pkg_schema` to be under 60 characters including the default server name.
 
 ### Changed
 

--- a/servers/mcp-neo4j-data-modeling/src/mcp_neo4j_data_modeling/server.py
+++ b/servers/mcp-neo4j-data-modeling/src/mcp_neo4j_data_modeling/server.py
@@ -413,8 +413,8 @@ def create_mcp_server(namespace: str = "") -> FastMCP:
         logger.info("Exporting a data model to Pydantic models.")
         return data_model_obj.to_pydantic_model_str()
 
-    @mcp.tool(name=namespace_prefix + "export_to_neo4j_graphrag_python_package_schema")
-    def export_to_neo4j_graphrag_python_package_schema(
+    @mcp.tool(name=namespace_prefix + "export_to_neo4j_graphrag_pkg_schema")
+    def export_to_neo4j_graphrag_pkg_schema(
         data_model: Union[str, DataModel],
     ) -> dict[str, Any]:
         """
@@ -428,8 +428,8 @@ def create_mcp_server(namespace: str = "") -> FastMCP:
         logger.info("Exporting a data model to a Neo4j Graphrag Python Package schema.")
         return data_model_obj.to_neo4j_graphrag_python_package_schema()
 
-    @mcp.tool(name=namespace_prefix + "load_from_neo4j_graphrag_python_package_schema")
-    def load_from_neo4j_graphrag_python_package_schema(
+    @mcp.tool(name=namespace_prefix + "load_from_neo4j_graphrag_pkg_schema")
+    def load_from_neo4j_graphrag_pkg_schema(
         neo4j_graphrag_python_package_schema: dict[str, Any],
     ) -> DataModel:
         """

--- a/servers/mcp-neo4j-data-modeling/tests/unit/test_server.py
+++ b/servers/mcp-neo4j-data-modeling/tests/unit/test_server.py
@@ -197,11 +197,22 @@ class TestMCPResources:
         assert len(tool_model.nodes) == len(resource_data["nodes"])
         assert len(tool_model.relationships) == len(resource_data["relationships"])
 
+    
+    @pytest.mark.asyncio
+    async def test_server_name_plus_tool_name_under_60_chars(self, test_mcp_server: FastMCP):
+        """
+        Test that the server name plus tool name is under 60 characters.
+        This is a requirement by some applications such as Cursor IDE.
+        """
+        tools = await test_mcp_server.get_tools()
+        for tool in tools:
+            assert len(test_mcp_server.name  + tool) <= 60
+
 
 class TestNamespacing:
     """Test namespacing functionality."""
 
-    def testformat_namespace(self):
+    def test_format_namespace(self):
         """Test the format_namespace function behavior."""
         from mcp_neo4j_data_modeling.server import format_namespace
 
@@ -337,7 +348,7 @@ async def test_load_from_neo4j_graphrag_python_package_schema_with_dict(
 
     # Get the tool function
     tools = await test_mcp_server.get_tools()
-    load_tool = tools.get("load_from_neo4j_graphrag_python_package_schema")
+    load_tool = tools.get("load_from_neo4j_graphrag_pkg_schema")
     assert load_tool is not None
 
     # Call with dict
@@ -348,3 +359,6 @@ async def test_load_from_neo4j_graphrag_python_package_schema_with_dict(
     assert len(result.nodes) == 1
     assert result.nodes[0].label == "City"
     assert result.nodes[0].key_property.name == "name"
+
+
+


### PR DESCRIPTION
# Description

Some applications such as Cursor IDE require that the MCP server name + tool name is <= 60 characters long. The Neo4j GraphRAG Package tool names need to be shortened to adhere to this requirement.


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity
- [x] LOW
- [ ] MEDIUM
- [ ] HIGH

Complexity:

## How Has This Been Tested?
- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] Integration tests have been updated
- [x] Server has been tested in an MCP application
- [x] CHANGELOG.md updated if appropriate