### PR TITLE
cypher and data modeling - update workflows to execute serially

### DIFF
--- a/.github/workflows/github-registry-cypher.yml
+++ b/.github/workflows/github-registry-cypher.yml
@@ -1,9 +1,6 @@
 name: Publish Cypher MCP to Github MCP Registry
 
 on:
-  push:
-    tags:
-      - 'mcp-neo4j-cypher-v*'
   workflow_dispatch:  # Allows manual triggering of the workflow
 
 jobs:

--- a/.github/workflows/github-registry-data-modeling.yml
+++ b/.github/workflows/github-registry-data-modeling.yml
@@ -1,13 +1,10 @@
 name: Publish Data Modeling MCP to Github MCP Registry
 
 on:
-  push:
-    tags:
-      - 'mcp-neo4j-data-modeling-v*'
   workflow_dispatch:  # Allows manual triggering of the workflow
 
 jobs:
-  publish:
+  mcp-registry-publish:
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # For OIDC

--- a/.github/workflows/publish-cypher.yml
+++ b/.github/workflows/publish-cypher.yml
@@ -77,3 +77,25 @@ jobs:
         run: |
           cd servers/mcp-neo4j-cypher/
           uv publish
+  mcp-registry-publish:
+    runs-on: ubuntu-latest
+    needs: pypi-publish
+    permissions:
+      id-token: write  # For OIDC
+      contents: read
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # MCP publishing (works for all package types)
+      - name: Download MCP Publisher
+        run: |
+          LATEST_VERSION=$(curl -s https://api.github.com/repos/modelcontextprotocol/registry/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/${LATEST_VERSION}/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz
+      - name: Publish to MCP Registry
+        run: |
+          chmod +x mcp-publisher
+          cd servers/mcp-neo4j-cypher/
+          ../../mcp-publisher login github-oidc
+          ../../mcp-publisher publish

--- a/.github/workflows/publish-data-modeling.yml
+++ b/.github/workflows/publish-data-modeling.yml
@@ -77,3 +77,25 @@ jobs:
         run: |
           cd servers/mcp-neo4j-data-modeling/
           uv publish
+  mcp-registry-publish:
+    runs-on: ubuntu-latest
+    needs: pypi-publish
+    permissions:
+      id-token: write  # For OIDC
+      contents: read
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # MCP publishing (works for all package types)
+      - name: Download MCP Publisher
+        run: |
+          LATEST_VERSION=$(curl -s https://api.github.com/repos/modelcontextprotocol/registry/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/${LATEST_VERSION}/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz
+      - name: Publish to MCP Registry
+        run: |
+          chmod +x mcp-publisher
+          cd servers/mcp-neo4j-data-modeling/
+          ../../mcp-publisher login github-oidc
+          ../../mcp-publisher publish


### PR DESCRIPTION
Publishing workflows would execute in parallel and MCP Registry publication would fail since it requires PyPI publishing to complete first. Now they execute serially and should succeed. This is how Aura Manager and Memory MCP server workflows function.