### PR TITLE
all - bump mcp registry schema versions to 2025-12-11

### DIFF
--- a/servers/mcp-neo4j-cloud-aura-api/server.json
+++ b/servers/mcp-neo4j-cloud-aura-api/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.neo4j-contrib/mcp-neo4j-aura-manager",
   "description": "MCP server for Neo4j Aura Database Instance Manager.",
   "repository": {

--- a/servers/mcp-neo4j-cypher/server.json
+++ b/servers/mcp-neo4j-cypher/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.neo4j-contrib/mcp-neo4j-cypher",
   "description": "A simple Neo4j MCP server that allows you to run Cypher queries against a Neo4j database.",
   "repository": {

--- a/servers/mcp-neo4j-memory/server.json
+++ b/servers/mcp-neo4j-memory/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.neo4j-contrib/mcp-neo4j-memory",
   "description": "MCP Neo4j Knowledge Graph Memory Server",
   "repository": {


### PR DESCRIPTION
# Description

bump mcp registry schema versions to 2025-12-11 in remaining MCP workflows


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [x] Project configuration change

## Complexity
- [x] LOW
- [ ] MEDIUM
- [ ] HIGH

Complexity:

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] Integration tests have been updated
- [ ] Server has been tested in an MCP application
- [ ] CHANGELOG.md updated if appropriate