### PR TITLE
chore: switch Docker images to non-root user and update libs

### DIFF
--- a/servers/mcp-neo4j-cloud-aura-api/Dockerfile
+++ b/servers/mcp-neo4j-cloud-aura-api/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install --no-cache-dir hatchling
 COPY pyproject.toml /app/
 
 # Install runtime dependencies
-RUN pip install --no-cache-dir fastmcp>=2.0.0 requests>=2.31.0 starlette>=0.40.0
+RUN pip install --no-cache-dir fastmcp>=2.11.0 requests>=2.31.0 starlette>=0.40.0
 
 # Copy the source code
 COPY src/ /app/src/
@@ -30,6 +30,11 @@ ENV NEO4J_MCP_SERVER_PORT=8000
 ENV NEO4J_MCP_SERVER_PATH="/mcp/"
 ENV NEO4J_MCP_SERVER_ALLOW_ORIGINS=""
 ENV NEO4J_MCP_SERVER_ALLOWED_HOSTS="localhost,127.0.0.1"
+
+# Create a non-root user and switch to it
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+RUN chown -R appuser:appuser /app
+USER appuser
 
 # Command to run the server using the package entry point
 CMD ["sh", "-c", "mcp-neo4j-aura-manager"]

--- a/servers/mcp-neo4j-cloud-aura-api/pyproject.toml
+++ b/servers/mcp-neo4j-cloud-aura-api/pyproject.toml
@@ -5,7 +5,7 @@ description = "MCP Neo4j Aura Database Instance Manager"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "fastmcp>=2.0.0",
+    "fastmcp>=2.11.0",
     "requests>=2.31.0",
     "starlette>=0.40.0",
 ]

--- a/servers/mcp-neo4j-cypher/Dockerfile
+++ b/servers/mcp-neo4j-cypher/Dockerfile
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir hatchling
 COPY pyproject.toml /app/
 
 # Install dependencies
-RUN pip install --no-cache-dir neo4j>=5.26.0 fastmcp>=2.10.5
+RUN pip install --no-cache-dir neo4j>=5.26.0 fastmcp>=2.11.0
 
 
 # Copy the source code
@@ -34,6 +34,11 @@ ENV NEO4J_MCP_SERVER_PORT="8000"
 ENV NEO4J_MCP_SERVER_PATH="/api/mcp/"
 ENV NEO4J_MCP_SERVER_ALLOW_ORIGINS=""
 ENV NEO4J_MCP_SERVER_ALLOWED_HOSTS="localhost,127.0.0.1"
+
+# Create a non-root user and switch to it
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+RUN chown -R appuser:appuser /app
+USER appuser
 
 EXPOSE 8000
 

--- a/servers/mcp-neo4j-cypher/pyproject.toml
+++ b/servers/mcp-neo4j-cypher/pyproject.toml
@@ -5,7 +5,7 @@ description = "A simple Neo4j MCP server"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "fastmcp>=2.10.5",
+    "fastmcp>=2.11.0",
     "neo4j>=5.26.0",
     "pydantic>=2.10.1",
     "tiktoken>=0.11.0",

--- a/servers/mcp-neo4j-data-modeling/Dockerfile
+++ b/servers/mcp-neo4j-data-modeling/Dockerfile
@@ -25,6 +25,10 @@ ENV NEO4J_MCP_SERVER_HOST="0.0.0.0"
 ENV NEO4J_MCP_SERVER_PORT="8000"
 ENV NEO4J_MCP_SERVER_PATH="/mcp/"
 
+# Create a non-root user and switch to it
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+RUN chown -R appuser:appuser /app
+USER appuser
 
 # Command to run the server using the package entry point
 CMD ["sh", "-c", "uv run mcp-neo4j-data-modeling"]

--- a/servers/mcp-neo4j-data-modeling/pyproject.toml
+++ b/servers/mcp-neo4j-data-modeling/pyproject.toml
@@ -5,7 +5,7 @@ description = "A simple Neo4j MCP server for creating graph data models."
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
 dependencies = [
-    "fastmcp>=2.0.0",
+    "fastmcp>=2.11.0",
     "pydantic>=2.10.1",
     "starlette>=0.47.0",
     "rdflib>=7.0.0",

--- a/servers/mcp-neo4j-memory/Dockerfile
+++ b/servers/mcp-neo4j-memory/Dockerfile
@@ -33,5 +33,10 @@ ENV NEO4J_MCP_SERVER_PATH="/api/mcp/"
 ENV NEO4J_MCP_SERVER_ALLOW_ORIGINS=""
 ENV NEO4J_MCP_SERVER_ALLOWED_HOSTS="localhost,127.0.0.1"
 
+# Create a non-root user and switch to it
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+RUN chown -R appuser:appuser /app
+USER appuser
+
 # Command to run the server using the package entry point
 CMD ["sh", "-c", "mcp-neo4j-memory"]

--- a/servers/mcp-neo4j-memory/pyproject.toml
+++ b/servers/mcp-neo4j-memory/pyproject.toml
@@ -5,10 +5,10 @@ description = "MCP Neo4j Knowledge Graph Memory Server"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "fastmcp>=2.0.0",
+    "fastmcp>=2.11.0",
     "neo4j>=5.26.0",
     "pydantic>=2.10.1",
-    "starlette>=0.28.0",
+    "starlette>=0.45.3",
 ]
 
 [build-system]


### PR DESCRIPTION
The current Docker setup runs everything as root by default, which might be an issue for deployments with strict security policies. I added a dedicated `appuser` to the Dockerfiles to handle permissions better.

Also, while checking the dependency trees, I noticed `fastmcp` and `starlette` were lagging behind on versions that have known CVEs. Bumped those up to the latest releases across all servers to clear out the warnings.