### PR TITLE
update read only check using EXPLAIN

### DIFF
--- a/servers/mcp-neo4j-cypher/CHANGELOG.md
+++ b/servers/mcp-neo4j-cypher/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 ### Changed
+* Update `_is_write_query` to use `EXPLAIN` query instead of regex check
 
 ### Added
 

--- a/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/server.py
+++ b/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/server.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import re
 from typing import Any, Literal, Optional
 
 from fastmcp.exceptions import ToolError
@@ -29,12 +28,15 @@ def _format_namespace(namespace: str) -> str:
         return ""
 
 
-def _is_write_query(query: str) -> bool:
-    """Check if the query is a write query."""
-    return (
-        re.search(r"\b(MERGE|CREATE|INSERT|SET|DELETE|REMOVE|ADD)\b", query, re.IGNORECASE)
-        is not None
+async def _is_write_query(query: str, driver: AsyncDriver, database: str) -> bool:
+    """Check if the query is a write query by running EXPLAIN and inspecting the query type."""
+    explain_query = "EXPLAIN " + query
+    _, summary, _ = await driver.execute_query(
+        query_=explain_query,
+        database_=database,
     )
+    # query_type is 'r', 'w', 'rw', or 's'; anything containing 'w' is a write
+    return "w" in (summary.query_type or "")
 
 
 def create_mcp_server(
@@ -191,7 +193,7 @@ def create_mcp_server(
     ) -> list[ToolResult]:
         """Execute a read Cypher query on the neo4j database."""
 
-        if _is_write_query(query):
+        if await _is_write_query(query, neo4j_driver, database):
             raise ValueError("Only MATCH queries are allowed for read-query")
 
         try:
@@ -241,7 +243,7 @@ def create_mcp_server(
     ) -> list[ToolResult]:
         """Execute a write Cypher query on the neo4j database."""
 
-        if not _is_write_query(query):
+        if not await _is_write_query(query, neo4j_driver, database):
             raise ValueError("Only write queries are allowed for write-query")
 
         try:

--- a/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/utils.py
+++ b/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/utils.py
@@ -313,12 +313,12 @@ def process_config(args: argparse.Namespace) -> dict[str, Union[str, int, None]]
                 logger.warning(
                     "Warning: Invalid sample size provided in NEO4J_SCHEMA_SAMPLE_SIZE environment variable. No default sample will be used."
                 )
-                config["schema_sample_size"] = 1000
+                config["schema_sample_size"] = None
         else:
             logger.info(
                 "Info: No default sample size provided. Schema operations will scan entire graph unless explicitly specified."
             )
-            config["schema_sample_size"] = 1000
+            config["schema_sample_size"] = None
 
     return config
 

--- a/servers/mcp-neo4j-cypher/tests/unit/test_utils.py
+++ b/servers/mcp-neo4j-cypher/tests/unit/test_utils.py
@@ -748,9 +748,9 @@ def test_read_only_defaults_and_precedence(clean_env, args_factory):
 
 def test_sample_cli_args(clean_env, args_factory):
     """Test sample configuration via CLI arguments."""
-    assert process_config(args_factory(sample=1000))["schema_sample_size"] == 1000
-    assert process_config(args_factory(sample=500))["schema_sample_size"] == 500
-    assert process_config(args_factory(sample=0))["schema_sample_size"] == 0
+    assert process_config(args_factory(schema_sample_size=1000))["schema_sample_size"] == 1000
+    assert process_config(args_factory(schema_sample_size=500))["schema_sample_size"] == 500
+    assert process_config(args_factory(schema_sample_size=0))["schema_sample_size"] == 0
 
 
 def test_sample_env_vars(clean_env, args_factory):
@@ -770,7 +770,7 @@ def test_sample_defaults(clean_env, args_factory):
 def test_sample_cli_overrides_env(clean_env, args_factory):
     """Test that CLI arguments override environment variables for sample."""
     os.environ["NEO4J_SCHEMA_SAMPLE_SIZE"] = "1000"
-    assert process_config(args_factory(sample=500))["schema_sample_size"] == 500
+    assert process_config(args_factory(schema_sample_size=500))["schema_sample_size"] == 500
 
 
 def test_sample_invalid_env_var(clean_env, args_factory, mock_logger):
@@ -779,7 +779,7 @@ def test_sample_invalid_env_var(clean_env, args_factory, mock_logger):
     config = process_config(args_factory())
     
     # Should default to None and log warning
-    assert config["sa"] is None
+    assert config["schema_sample_size"] is None
     mock_logger.warning.assert_called_with(
         "Warning: Invalid sample size provided in NEO4J_SCHEMA_SAMPLE_SIZE environment variable. No default sample will be used."
     )


### PR DESCRIPTION
# Description

Update read only check using EXPLAIN instead of regex checks. This is more secure and relies on database level read categorization instead of regex keyword matching.


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity
- [x] LOW
- [ ] MEDIUM
- [ ] HIGH

Complexity:

## How Has This Been Tested?
- [x] Unit tests
- [x] Integration tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [x] Integration tests have been updated
- [ ] Server has been tested in an MCP application
- [x] CHANGELOG.md updated if appropriate