### PR TITLE
fix(cypher): bind sample_size as Cypher param in get_neo4j_schema

### DIFF
--- a/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/server.py
+++ b/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/server.py
@@ -13,7 +13,7 @@ from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 
-from .utils import _truncate_string_to_tokens, _value_sanitize
+from .utils import _truncate_string_to_tokens, _value_sanitize, build_get_schema_query
 
 logger = logging.getLogger("mcp_neo4j_cypher")
 
@@ -83,7 +83,7 @@ def create_mcp_server(
 
         logger.info(f"Running `get_neo4j_schema` with sample size {effective_sample_size}.")
 
-        get_schema_query = f"CALL apoc.meta.schema({{sample: {effective_sample_size}}}) YIELD value RETURN value"
+        get_schema_query, schema_params = build_get_schema_query(effective_sample_size)
 
         def clean_schema(schema: dict) -> dict:
             cleaned = {}
@@ -147,6 +147,7 @@ def create_mcp_server(
         try:
             results_json = await neo4j_driver.execute_query(
                 get_schema_query,
+                parameters_=schema_params,
                 routing_control=RoutingControl.READ,
                 database_=database,
                 result_transformer_=lambda r: r.data(),

--- a/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/utils.py
+++ b/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/utils.py
@@ -1,12 +1,22 @@
 import argparse
 import logging
 import os
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 import tiktoken
 
 logger = logging.getLogger("mcp_neo4j_cypher")
 logger.setLevel(logging.INFO)
+
+
+def build_get_schema_query(sample_size: Optional[int]) -> tuple[str, dict]:
+    """Build the (cypher, params) pair for ``apoc.meta.schema``; falsy sample_size omits the sample arg."""
+    if not sample_size:
+        return ("CALL apoc.meta.schema() YIELD value RETURN value", {})
+    return (
+        "CALL apoc.meta.schema({sample: $sample_size}) YIELD value RETURN value",
+        {"sample_size": int(sample_size)},
+    )
 
 
 def parse_boolean_safely(value: Union[str, bool]) -> bool:

--- a/servers/mcp-neo4j-cypher/tests/integration/conftest.py
+++ b/servers/mcp-neo4j-cypher/tests/integration/conftest.py
@@ -61,6 +61,14 @@ async def mcp_server_short_timeout(async_neo4j_driver):
     return mcp
 
 
+@pytest_asyncio.fixture(scope="function")
+async def mcp_server_no_default_sample(async_neo4j_driver):
+    """MCP server with config_sample_size=None (the unconfigured-deployment default)."""
+    mcp = create_mcp_server(async_neo4j_driver, "neo4j", config_sample_size=None)
+
+    return mcp
+
+
 @pytest.fixture(scope="function")
 def init_data(setup: Neo4jContainer, clear_data: Any):
     with setup.get_driver().session(database="neo4j") as session:

--- a/servers/mcp-neo4j-cypher/tests/integration/test_server_tools_IT.py
+++ b/servers/mcp-neo4j-cypher/tests/integration/test_server_tools_IT.py
@@ -21,6 +21,18 @@ async def test_get_neo4j_schema(mcp_server: FastMCP, init_data: Any):
 
 
 @pytest.mark.asyncio(loop_scope="function")
+async def test_get_neo4j_schema_no_configured_sample_size(
+    mcp_server_no_default_sample: FastMCP, init_data: Any
+):
+    tool = await mcp_server_no_default_sample.get_tool("get_neo4j_schema")
+    response = await tool.run(dict())
+
+    schema = json.loads(response.content[0].text)
+    assert "Person" in schema
+    assert schema["Person"]["count"] == 3
+
+
+@pytest.mark.asyncio(loop_scope="function")
 async def test_write_neo4j_cypher(mcp_server: FastMCP):
     query = "CREATE (n:Test {name: 'test', age: 123}) RETURN n.name"
     tool = await mcp_server.get_tool("write_neo4j_cypher")

--- a/servers/mcp-neo4j-cypher/tests/unit/test_get_schema_query.py
+++ b/servers/mcp-neo4j-cypher/tests/unit/test_get_schema_query.py
@@ -1,0 +1,22 @@
+import pytest
+
+from mcp_neo4j_cypher.utils import build_get_schema_query
+
+NO_SAMPLE_QUERY = "CALL apoc.meta.schema() YIELD value RETURN value"
+SAMPLED_QUERY = "CALL apoc.meta.schema({sample: $sample_size}) YIELD value RETURN value"
+
+
+@pytest.mark.parametrize("sample_size", [None, 0])
+def test_falsy_sample_size_omits_sample_argument(sample_size):
+    query, params = build_get_schema_query(sample_size)
+    assert query == NO_SAMPLE_QUERY
+    assert "None" not in query
+    assert params == {}
+
+
+@pytest.mark.parametrize("sample_size", [1, 500, 1000, -1])
+def test_truthy_sample_size_binds_parameter(sample_size):
+    query, params = build_get_schema_query(sample_size)
+    assert query == SAMPLED_QUERY
+    assert str(sample_size) not in query
+    assert params == {"sample_size": sample_size}


### PR DESCRIPTION
## Description

`get_neo4j_schema` fails with `CypherSyntaxError: Variable \`None\` not defined` when no sample size is configured — the f-string interpolates `None` as a literal Cypher identifier:

```cypher
CALL apoc.meta.schema({sample: None}) YIELD value RETURN value
```

Easy to hit with a bare `uvx mcp-neo4j-cypher` invocation.

## Fix

Bind `sample_size` as a Cypher parameter (matching `read_neo4j_cypher` / `write_neo4j_cypher`); omit the `sample` arg entirely when falsy so APOC falls back to its default.

## Testing

- Unit tests over `build_get_schema_query` for falsy/truthy inputs
- Integration test exercising `get_neo4j_schema` with `config_sample_size=None` against testcontainers Neo4j