### PR TITLE
fix(docker): bound fastmcp<3 in server Dockerfiles (3.x removed PrivateKeyJWTClientAuthenticator → ImportError)

### DIFF
--- a/servers/mcp-neo4j-cloud-aura-api/Dockerfile
+++ b/servers/mcp-neo4j-cloud-aura-api/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install --no-cache-dir hatchling
 COPY pyproject.toml /app/
 
 # Install runtime dependencies
-RUN pip install --no-cache-dir fastmcp>=2.0.0 requests>=2.31.0 starlette>=0.40.0
+RUN pip install --no-cache-dir "fastmcp>=2.0.0,<3" "requests>=2.31.0" "starlette>=0.40.0"
 
 # Copy the source code
 COPY src/ /app/src/

--- a/servers/mcp-neo4j-cypher/Dockerfile
+++ b/servers/mcp-neo4j-cypher/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install --no-cache-dir hatchling
 COPY pyproject.toml /app/
 
 # Install dependencies
-RUN pip install --no-cache-dir neo4j>=5.26.0 fastmcp>=2.10.5
+RUN pip install --no-cache-dir "neo4j>=5.26.0" "fastmcp>=2.10.5,<3"
 
 
 # Copy the source code

--- a/servers/mcp-neo4j-memory/Dockerfile
+++ b/servers/mcp-neo4j-memory/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install --no-cache-dir hatchling
 COPY pyproject.toml /app/
 
 # Install runtime dependencies
-RUN pip install --no-cache-dir fastmcp>=2.0.0 neo4j>=5.26.0
+RUN pip install --no-cache-dir "fastmcp>=2.0.0,<3" "neo4j>=5.26.0"
 
 # Copy the source code
 COPY src/ /app/src/


### PR DESCRIPTION
### Problem

The server Dockerfiles install `fastmcp` with an **unquoted, unbounded** constraint, e.g. `servers/mcp-neo4j-memory/Dockerfile`:

```dockerfile
RUN pip install --no-cache-dir fastmcp>=2.0.0 neo4j>=5.26.0
```

Two issues:
1. **Unquoted `>=`** — `>` is a shell redirection metacharacter, so the version spec isn't reliably passed to pip.
2. **No upper bound** — pip resolves to the newest release, currently **fastmcp 3.x**.

FastMCP 3.0 removed `PrivateKeyJWTClientAuthenticator` from `fastmcp.server.auth.auth`, so a freshly built image crashes at startup:

```
ImportError: cannot import name 'PrivateKeyJWTClientAuthenticator' from 'fastmcp.server.auth.auth'
```

`servers/mcp-neo4j-memory/pyproject.toml` already declares `fastmcp>=2.0.0,<3` — the Dockerfile just didn't match it.

### Fix

Quote each requirement and bound `fastmcp<3` in the three affected server Dockerfiles (`mcp-neo4j-memory`, `mcp-neo4j-cypher`, `mcp-neo4j-cloud-aura-api`), matching the packages' 2.x API usage. No functional change beyond constraining the dependency to the supported major.
