### PR TITLE
change default schema sample size to 1000 when unset

### DIFF
--- a/servers/mcp-neo4j-cypher/CHANGELOG.md
+++ b/servers/mcp-neo4j-cypher/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 ### Fixed
+* Default `schema_sample_size` to `1000` when CLI and env are unset so `get_neo4j_schema` does not interpolate `{sample: None}`
 
 ### Changed
 

--- a/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/utils.py
+++ b/servers/mcp-neo4j-cypher/src/mcp_neo4j_cypher/utils.py
@@ -316,9 +316,9 @@ def process_config(args: argparse.Namespace) -> dict[str, Union[str, int, None]]
                 config["schema_sample_size"] = None
         else:
             logger.info(
-                "Info: No default sample size provided. Schema operations will scan entire graph unless explicitly specified."
+                "Info: No sample size provided. Using default: 1000"
             )
-            config["schema_sample_size"] = None
+            config["schema_sample_size"] = 1000
 
     return config
 

--- a/servers/mcp-neo4j-cypher/tests/unit/test_utils.py
+++ b/servers/mcp-neo4j-cypher/tests/unit/test_utils.py
@@ -764,7 +764,7 @@ def test_sample_env_vars(clean_env, args_factory):
 
 def test_sample_defaults(clean_env, args_factory):
     """Test sample defaults when not provided."""
-    assert process_config(args_factory())["schema_sample_size"] is None
+    assert process_config(args_factory())["schema_sample_size"] == 1000
 
 
 def test_sample_cli_overrides_env(clean_env, args_factory):


### PR DESCRIPTION
# Description
Unset sample size was stored as None and broke apoc.meta.schema. Use the APOC default of 1000.

Fixes #297
Supersedes #288

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity
- [x] LOW
- [ ] MEDIUM
- [ ] HIGH

Complexity: One default in `process_config` and the existing unit test assertion.

## How Has This Been Tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] Integration tests have been updated
- [x] Server has been tested in an MCP application
- [x] CHANGELOG.md updated if appropriate